### PR TITLE
Validate theme die types before rolls / warn on incomplete themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ foundry.js
 dist
 /.parcel-cache/
 /data/
+tests/results/

--- a/src/dddice.ts
+++ b/src/dddice.ts
@@ -12,6 +12,11 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 import { ConfigPanel } from './module/ConfigPanel';
+import {
+  formatMissingDieTypesError,
+  getMissingDieTypesForRoll,
+  isFullPolyhedralTheme,
+} from './module/helper/themeDice';
 import createLogger from './module/log';
 import {
   convertDddiceRollModelToFVTTRollModel,
@@ -38,6 +43,25 @@ declare global {
 let dddice: ThreeDDice;
 let api: ThreeDDiceAPI;
 
+const assertThemeSupportsRoll = (
+  theme: ITheme | undefined,
+  dice: { type?: string }[],
+  context?: string,
+) => {
+  const missingTypes = getMissingDieTypesForRoll(theme, dice);
+  if (missingTypes.length === 0) {
+    return;
+  }
+  log.warn('theme missing die types for roll', {
+    themeId: theme?.id,
+    themeName: theme?.name,
+    availableDice: theme?.available_dice,
+    missingTypes,
+    context,
+  });
+  throw new Error(formatMissingDieTypesError(theme, missingTypes));
+};
+
 const showForRoll = (...args) => {
   const room = getCurrentRoom();
   const theme = getCurrentTheme();
@@ -45,11 +69,17 @@ const showForRoll = (...args) => {
   const dddiceRoll = convertFVTTRollModelToDddiceRollModel([args[0]], theme?.id as string);
   const uuid = 'dsnFreeRoll:' + uuidv4();
   if (room && theme && dddiceRoll) {
-    api.roll.create(dddiceRoll.dice, {
-      room: room.slug,
-      operator: dddiceRoll.operator,
-      external_id: uuid,
-    });
+    try {
+      assertThemeSupportsRoll(theme, dddiceRoll.dice, args[0]?._formula);
+      api.roll.create(dddiceRoll.dice, {
+        room: room.slug,
+        operator: dddiceRoll.operator,
+        external_id: uuid,
+      });
+    } catch (e) {
+      console.error(e);
+      ui.notifications?.error(`dddice | ${e.response?.data?.data?.message ?? e.message ?? e}`);
+    }
   }
   return new Promise<void>(resolve => {
     pendingRollsFromShowForRoll.set(uuid, resolve);
@@ -254,6 +284,8 @@ const rollDiceFromChatMessage = async (chatMessage: ChatMessage) => {
           const dddiceRoll = convertFVTTDiceEquation(roll, theme?.id);
           log.debug('formatted dddice roll', dddiceRoll);
           if (chatMessage.isAuthor && dddiceRoll.dice.length > 0) {
+            assertThemeSupportsRoll(theme, dddiceRoll.dice, roll._formula);
+
             let participantIds;
             const whisper: IUser[] = chatMessage.whisper.map(
               user =>
@@ -293,7 +325,7 @@ const rollDiceFromChatMessage = async (chatMessage: ChatMessage) => {
           }
         } catch (e) {
           console.error(e);
-          ui.notifications?.error(`dddice | ${e.response?.data?.data?.message ?? e}`);
+          ui.notifications?.error(`dddice | ${e.response?.data?.data?.message ?? e.message ?? e}`);
           document
             .querySelector(`[data-message-id='${chatMessage.id}']`)
             ?.classList.remove('!dddice-hidden');
@@ -370,19 +402,7 @@ async function createGuestUserIfNeeded() {
   } else {
     log.info('pick random theme');
     didSetup = true;
-    const themes = (await api.diceBox.list()).data.filter(theme =>
-      Object.values(
-        theme.available_dice
-          .map(die => die.type ?? die)
-          .reduce(
-            (prev, curr) => {
-              prev[curr] = true;
-              return prev;
-            },
-            { d4: false, d6: false, d8: false, d10: false, d10x: false, d20: false },
-          ),
-      ).every(type => type),
-    );
+    const themes = (await api.diceBox.list()).data.filter(isFullPolyhedralTheme);
     await game.settings.set(
       'dddice',
       'theme',

--- a/src/module/components/Theme.tsx
+++ b/src/module/components/Theme.tsx
@@ -39,7 +39,12 @@ const Theme = (props: IThemeProps) => {
           )*/}
         </div>
         <div data-tip="switch dice">
-          <ThemeCard theme={theme} onClick={() => onSwitchTheme()} key={theme.id} />
+          <ThemeCard
+            theme={theme}
+            onClick={() => onSwitchTheme()}
+            key={theme.id}
+            showCompletenessWarning
+          />
         </div>
       </div>
     );

--- a/src/module/components/ThemeCard.tsx
+++ b/src/module/components/ThemeCard.tsx
@@ -3,16 +3,22 @@
 import React from 'react';
 import { ITheme } from 'dddice-js';
 
+import { getThemeDieTypes, isFullPolyhedralTheme } from '../helper/themeDice';
+
 interface IRoomCardProps {
   theme: ITheme;
   onClick();
   key?: string;
+  showCompletenessWarning?: boolean;
 }
 
 const ThemeCard = (props: IRoomCardProps) => {
-  const { theme, onClick } = props;
+  const { theme, onClick, showCompletenessWarning = true } = props;
 
   if (theme) {
+    const isComplete = isFullPolyhedralTheme(theme);
+    const availableTypes = [...getThemeDieTypes(theme)].sort().join(', ');
+
     return (
       <div
         key={theme.id}
@@ -23,11 +29,28 @@ const ThemeCard = (props: IRoomCardProps) => {
         }}
         onClick={() => onClick()}
       >
-        <div className="flex flex-row">
+        <div className="flex flex-row items-center gap-2">
           <div className="flex text-white rounded bg-gray-800 bg-opacity-50 px-1 text-lg font-bold">
             {theme.name}
           </div>
+          {showCompletenessWarning && !isComplete && (
+            <div
+              className="flex text-warning rounded bg-gray-900 bg-opacity-70 px-1 text-xs font-semibold ml-auto"
+              title={
+                availableTypes
+                  ? `Available dice: ${availableTypes}. Missing standard dice may fail Foundry rolls.`
+                  : 'This theme is missing standard polyhedral dice.'
+              }
+            >
+              Incomplete set
+            </div>
+          )}
         </div>
+        {showCompletenessWarning && !isComplete && (
+          <div className="mt-1 text-warning text-xs rounded bg-gray-900 bg-opacity-70 px-1 w-fit">
+            May not support d20 / full polyhedral rolls
+          </div>
+        )}
       </div>
     );
   }

--- a/src/module/components/ThemeSelection.tsx
+++ b/src/module/components/ThemeSelection.tsx
@@ -40,6 +40,10 @@ const ThemeSelection = (props: IThemes) => {
           connect your account
         </DddiceButton>
       </div>
+      <div className="text-warning text-xs m-auto mt-2 text-center px-2">
+        Themes marked incomplete are missing standard dice (like d20) and will fail those rolls in
+        Foundry.
+      </div>
       {themes?.length > 0 && (
         <div className="overflow-y-auto scroll mt-2">
           {themes.map((theme: ITheme) => (

--- a/src/module/helper/themeDice.ts
+++ b/src/module/helper/themeDice.ts
@@ -1,0 +1,75 @@
+/** @format */
+
+import { ITheme } from 'dddice-js';
+
+/** Standard polyhedral set used for guest auto-pick and UI completeness checks. */
+export const FULL_POLYHEDRAL_TYPES = ['d4', 'd6', 'd8', 'd10', 'd10x', 'd20'] as const;
+
+type ThemeDieEntry = {
+  type?: string;
+  notation?: string;
+  id?: string;
+};
+
+/** True for values like d20 / d10x that identify a die type (not UUIDs). */
+function looksLikeDieType(value: string | undefined | null): value is string {
+  return Boolean(value && /^d\d+x?$/i.test(value));
+}
+
+/**
+ * Collect die-type identifiers from a theme's available_dice.
+ * Some themes (e.g. Spiral Dice) expose percentile as `{ id: "d10x", type: "d10", notation: "d10x" }`,
+ * so we must consider notation/id as well as type.
+ */
+export function getThemeDieTypes(theme: ITheme | undefined | null): Set<string> {
+  if (!theme?.available_dice?.length) {
+    return new Set();
+  }
+  const types = new Set<string>();
+  for (const die of theme.available_dice) {
+    if (typeof die === 'string') {
+      if (looksLikeDieType(die)) {
+        types.add(die);
+      }
+      continue;
+    }
+    const entry = die as ThemeDieEntry;
+    for (const candidate of [entry.type, entry.notation, entry.id]) {
+      if (looksLikeDieType(candidate)) {
+        types.add(candidate);
+      }
+    }
+  }
+  return types;
+}
+
+export function isFullPolyhedralTheme(theme: ITheme | undefined | null): boolean {
+  const available = getThemeDieTypes(theme);
+  return FULL_POLYHEDRAL_TYPES.every(type => available.has(type));
+}
+
+export function getMissingDieTypesForRoll(
+  theme: ITheme | undefined | null,
+  dice: Array<{ type?: string }> | undefined | null,
+): string[] {
+  // Stale/partial theme caches may omit available_dice; defer to the API in that case.
+  if (!theme?.available_dice?.length) {
+    return [];
+  }
+  const available = getThemeDieTypes(theme);
+  const requested = new Set(
+    (dice ?? [])
+      .map(die => die.type)
+      .filter((type): type is string => Boolean(type) && type !== 'mod'),
+  );
+  return [...requested].filter(type => !available.has(type)).sort();
+}
+
+export function formatMissingDieTypesError(
+  theme: ITheme | undefined | null,
+  missingTypes: string[],
+): string {
+  const themeName = theme?.name ? `"${theme.name}"` : 'the selected theme';
+  const missing = missingTypes.join(', ');
+  return `${missing} not available in ${themeName}. Switch to a theme that includes ${missing} in dddice settings.`;
+}

--- a/static/module.json
+++ b/static/module.json
@@ -1,10 +1,9 @@
 {
   "id": "dddice",
-  "name": "dddice",
   "title": "dddice - 3D Dice Roller",
   "description": "Roll 3D digital dice using Foundry VTT.",
   "version": "This is auto replaced",
-  "library": "false",
+  "library": false,
   "compatibility": {
     "verified": "14.363",
     "minimum": "14.0"
@@ -14,7 +13,6 @@
       "name": "dddice"
     }
   ],
-  "conflicts": [],
   "esmodules": ["dddice.js"],
   "scripts": [],
   "styles": ["dddice.css"],

--- a/static/module.json
+++ b/static/module.json
@@ -5,7 +5,7 @@
   "version": "This is auto replaced",
   "library": false,
   "compatibility": {
-    "verified": "14.363",
+    "verified": "14.365",
     "minimum": "14.0"
   },
   "authors": [

--- a/tests/themeDice.spec.ts
+++ b/tests/themeDice.spec.ts
@@ -1,0 +1,92 @@
+/** @format */
+
+import { describe, expect, it } from '@jest/globals';
+import { ITheme } from 'dddice-js';
+
+import {
+  formatMissingDieTypesError,
+  getMissingDieTypesForRoll,
+  getThemeDieTypes,
+  isFullPolyhedralTheme,
+} from '../src/module/helper/themeDice';
+
+const themeWith = (available_dice: ITheme['available_dice'], name = 'Test Theme'): ITheme =>
+  ({
+    id: 'theme-1',
+    name,
+    available_dice,
+  }) as ITheme;
+
+describe('themeDice helpers', () => {
+  it('reads string and object available_dice entries', () => {
+    const theme = themeWith(['d6', { type: 'd20' } as any]);
+    expect([...getThemeDieTypes(theme)].sort()).toEqual(['d20', 'd6']);
+  });
+
+  it('treats notation/id as die types when type is a mesh alias (e.g. d10x)', () => {
+    const theme = themeWith([
+      { id: 'd4', type: 'd4', notation: 'd4' },
+      { id: 'd6', type: 'd6', notation: 'd6' },
+      { id: 'd8', type: 'd8', notation: 'd8' },
+      { id: 'd10', type: 'd10', notation: 'd10' },
+      { id: 'd10x', type: 'd10', notation: 'd10x' },
+      { id: 'd12', type: 'd12', notation: 'd12' },
+      { id: '8a740633-a462-4e56-b8d5-0b6f813823e9', type: 'd20', notation: 'd20' },
+    ] as any);
+
+    expect([...getThemeDieTypes(theme)].sort()).toEqual([
+      'd10',
+      'd10x',
+      'd12',
+      'd20',
+      'd4',
+      'd6',
+      'd8',
+    ]);
+    expect(isFullPolyhedralTheme(theme)).toBe(true);
+    expect(getMissingDieTypesForRoll(theme, [{ type: 'd10x' }, { type: 'd20' }])).toEqual([]);
+  });
+
+  it('ignores UUID-only ids that are not die type labels', () => {
+    const theme = themeWith([
+      { id: '8a740633-a462-4e56-b8d5-0b6f813823e9', type: 'd20', notation: 'd20' },
+    ] as any);
+    expect([...getThemeDieTypes(theme)].sort()).toEqual(['d20']);
+  });
+
+  it('detects full polyhedral themes', () => {
+    expect(
+      isFullPolyhedralTheme(themeWith(['d4', 'd6', 'd8', 'd10', 'd10x', 'd20', 'd12'])),
+    ).toBe(true);
+    expect(isFullPolyhedralTheme(themeWith(['d6', 'd20']))).toBe(false);
+  });
+
+  it('finds missing die types for a roll', () => {
+    const theme = themeWith(['d6', 'd8']);
+    expect(
+      getMissingDieTypesForRoll(theme, [
+        { type: 'd20' },
+        { type: 'd6' },
+        { type: 'mod' },
+        { type: 'd20' },
+      ]),
+    ).toEqual(['d20']);
+  });
+
+  it('skips validation when available_dice is missing from cached theme', () => {
+    const theme = themeWith(undefined as any);
+    expect(getMissingDieTypesForRoll(theme, [{ type: 'd20' }])).toEqual([]);
+  });
+
+  it('allows d20 rolls against a full polyhedral theme', () => {
+    const theme = themeWith(['d4', 'd6', 'd8', 'd10', 'd10x', 'd20', 'd12']);
+    expect(getMissingDieTypesForRoll(theme, [{ type: 'd20' }, { type: 'd6' }])).toEqual([]);
+  });
+
+  it('formats a clear error for missing die types', () => {
+    const theme = themeWith(['d6'], 'Marble d6s');
+    expect(formatMissingDieTypesError(theme, ['d20'])).toBe(
+      'd20 not available in "Marble d6s". Switch to a theme that includes d20 in dddice settings.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Pre-validate Foundry rolls against the selected dddice theme’s `available_dice`, and show a clear error when required types (e.g. `d20`) are missing instead of only surfacing the opaque API message.
- Mark incomplete themes in the picker / selected-theme UI so specialty or partial sets are obvious before rolling.
- Treat `notation` / `id` as die types when present (e.g. Spiral Dice percentile: `type: "d10"`, `notation`/`id: "d10x"`), so full-set checks and roll validation stay accurate.
- Clean Foundry v14 unknown manifest keys (`conflicts`, deprecated `name`) and use a boolean `library` field.

## Attribution
This PR was **drafted with Cursor** (AI-assisted coding). It was **tested by a human**: **Matthew Clark**.

## Test plan
- [ ] Unit: `npm test -- --testPathPattern=themeDice`
- [ ] Foundry v14: select an incomplete theme → roll `d20` → clear notification naming theme + missing types
- [ ] Foundry v14: select a full polyhedral theme (including Spiral Dice / `d10x` via notation) → `d20` / percentile rolls succeed
- [ ] Theme picker shows “Incomplete set” for partial themes
- [ ] No Foundry warning about unknown `conflicts` / `name` keys in `module.json`